### PR TITLE
Fix for Statusbar Vowifi icon overlap mobile signal icon. 1/2

### DIFF
--- a/res/values/cherish_arrays.xml
+++ b/res/values/cherish_arrays.xml
@@ -142,19 +142,6 @@
         <item>8</item>
     </string-array>
 
-    <!-- VoWiFi Icon -->
-    <string-array name="vowifi_icon_entries" translatable="false">
-        <item>@string/vowifi_icon_disabled</item>
-        <item>@string/vowifi_icon_enabled</item>
-        <item>@string/vowifi_icon_enabled_volte_disabled</item>
-    </string-array>
-
-    <string-array name="vowifi_icon_values" translatable="false">
-        <item>0</item>
-        <item>1</item>
-        <item>2</item>
-    </string-array>
-
     <!-- VoWiFi icon style -->
     <string-array name="vowifi_icon_style_entries" translatable="false">
         <item>@string/vowifi_icon_default</item>

--- a/res/values/cherish_strings.xml
+++ b/res/values/cherish_strings.xml
@@ -256,9 +256,7 @@
 
     <!-- VoWiFi icon -->
     <string name="vowifi_icon_title">VoWiFi icon</string>
-    <string name="vowifi_icon_enabled">VoWiFi icon enabled</string>
-    <string name="vowifi_icon_disabled">VoWiFi icon disabled</string>
-    <string name="vowifi_icon_enabled_volte_disabled">VoWiFi instead of VoLTE icon</string>
+    <string name="vowifi_switch_summary">VoWiFi instead of VoLTE icon</string>
     <string name="vowifi_icon_style_title">VoWiFi icon style</string>
     <string name="vowifi_icon_default">Default Icon</string>
     <string name="vowifi_icon_emui">EMUI Icon</string>

--- a/res/xml/cherish_settings_statusbar.xml
+++ b/res/xml/cherish_settings_statusbar.xml
@@ -100,7 +100,8 @@
          android:entries="@array/vowifi_icon_style_entries"
          android:entryValues="@array/vowifi_icon_style_values"
          android:summary="%s"
-         android:defaultValue="0"/>
+         android:defaultValue="0"
+	 android:dependency="vowifi_icon"/>
 
     <Preference
             android:key="battery_bar_category"

--- a/res/xml/cherish_settings_statusbar.xml
+++ b/res/xml/cherish_settings_statusbar.xml
@@ -86,14 +86,12 @@
          android:defaultValue="0"
          android:dependency="show_volte_icon"/>
 
-    <com.cherish.settings.preferences.SystemSettingListPreference
+    <com.cherish.settings.preferences.SystemSettingSwitchPreference
          android:key="vowifi_icon"
 	 android:icon="@drawable/ic_vowifi"
          android:title="@string/vowifi_icon_title"
-         android:entries="@array/vowifi_icon_entries"
-         android:entryValues="@array/vowifi_icon_values"
-         android:summary="%s"
-         android:defaultValue="0"/>
+         android:summary="@string/vowifi_switch_summary"
+         android:defaultValue="false"/>
 
     <com.cherish.settings.preferences.SystemSettingListPreference
          android:key="vowifi_icon_style"


### PR DESCRIPTION
Changed to switch to enable (replace VoLTE) or disable VoWifi icon (CherishSettings). If enabled the VoWifi icon will replace the VoLTE icon on the statusbar if the service is available (frameworks base).