### PR TITLE
Update cherish_maintainers.xml for New Maintainer of Avicii

### DIFF
--- a/res/values/cherish_maintainers.xml
+++ b/res/values/cherish_maintainers.xml
@@ -150,7 +150,7 @@
    <string name="device_lemonades">Oneplus 9R</string>
    <string name="lemonades_maintainer">Viper_1057 or Amsal1</string>
    <string name="device_avicii">Oneplus Nord</string>
-   <string name="avicii_maintainer">Snippetguy</string>
+   <string name="avicii_maintainer">PSavarMattas</string>
 
    <!-- Lenovo Device maintainers -->
    <string name="device_jd2019">Lenovo Z5s</string>


### PR DESCRIPTION
The maintainer name string is updated for OnePlus Nord (Avicii) to PsavarMattas.